### PR TITLE
Fix `checkRd` issues

### DIFF
--- a/R/423-extractProtPSSMAcc.R
+++ b/R/423-extractProtPSSMAcc.R
@@ -20,8 +20,7 @@
 #' @export extractProtPSSMAcc
 #'
 #' @references
-#' Wold, S., Jonsson, J., Sj\"{o}rstr\"{o}m, M., Sandberg,
-#' M., & R\"{a}nnar, S. (1993).
+#' Wold, S., Jonsson, J., Sjörström, M., Sandberg, M., & Rännar, S. (1993).
 #' DNA and peptide sequences and chemical processes multivariately modelled
 #' by principal component analysis and partial least-squares projections
 #' to latent structures.

--- a/R/501-readFASTA.R
+++ b/R/501-readFASTA.R
@@ -1,30 +1,25 @@
 #' Read Protein Sequences in FASTA Format
 #'
-#' Read Protein Sequences in FASTA Format
+#' Reads protein sequences in FASTA format.
 #'
-#' This function reads protein sequences in FASTA format.
-#'
-#' @param file   The name of the file which the sequences in fasta format are
-#'               to be read from. If it does not contain an absolute or
-#'               relative path, the file name is relative to the current
-#'               working directory, \code{\link{getwd}}.
-#'               The default here is to read the \code{P00750.fasta} file which
-#'               is present in the \code{protseq} directory of the Rcpi package.
+#' @param file The name of the file which the sequences in fasta format are
+#'   to be read from. If it does not contain an absolute or
+#'   relative path, the file name is relative to the current
+#'   working directory, \code{\link{getwd}}.
+#'   The default here is to read the \code{P00750.fasta} file which
+#'   is present in the \code{protseq} directory of the Rcpi package.
 #'
 #' @param legacy.mode If set to \code{TRUE}, lines starting with a semicolon ';'
-#'                    are ignored. Default value is \code{TRUE}.
-#' @param seqonly     If set to \code{TRUE}, only sequences as returned without
-#'                    attempt to modify them or to get their names and
-#'                    annotations (execution time is divided approximately
-#'                    by a factor 3). Default value is \code{FALSE}.
+#'   are ignored. Default value is \code{TRUE}.
+#' @param seqonly If set to \code{TRUE}, only sequences as returned without
+#'   attempt to modify them or to get their names and
+#'   annotations (execution time is divided approximately
+#'   by a factor 3). Default value is \code{FALSE}.
 #'
-#' @return The result character vector
+#' @return Character vector.
 #'
-#' @note Note that any different sets of instances (chunklets),
-#'       e.g. {1, 3, 7} and {4, 6}, might belong to the
-#'       same class and might belong to different classes.
-#'
-#' @seealso See \code{\link{readPDB}} for reading protein sequences
+#' @seealso
+#' See \code{\link{readPDB}} for reading protein sequences
 #' in PDB format.
 #'
 #' @export readFASTA
@@ -33,7 +28,7 @@
 #' Pearson, W.R. and Lipman, D.J. (1988)
 #' Improved tools for biological sequence comparison.
 #' \emph{Proceedings of the National Academy of Sciences
-#' of the United States of America}, \bold{85}: 2444-2448
+#' of the United States of America}, 85: 2444-2448.
 #'
 #' @examples
 #' P00750 = readFASTA(system.file('protseq/P00750.fasta', package = 'Rcpi'))

--- a/R/508-acc.R
+++ b/R/508-acc.R
@@ -1,25 +1,23 @@
 #' Auto Cross Covariance (ACC) for Generating Scales-Based Descriptors
 #' of the Same Length
 #'
-#' Auto Cross Covariance (ACC) for Generating Scales-Based Descriptors
-#' of the Same Length
-#'
-#' This function calculates the auto covariance and auto cross covariance
+#' Calculates auto covariance and auto cross covariance
 #' for generating scale-based descriptors of the same length.
 #'
 #' @param mat A \code{p * n} matrix. Each row represents one scale
-#' (total \code{p} scales), each column represents one amino acid position
-#' (total \code{n} amino acids).
+#'   (total \code{p} scales), each column represents one amino acid position
+#'   (total \code{n} amino acids).
 #'
 #' @param lag The lag parameter. Must be less than the amino acids.
 #'
 #' @return A length \code{lag * p^2} named vector, the element names are
-#'         constructed by: the scales index (crossed scales index) and
-#'         lag index.
+#'   constructed by: the scales index (crossed scales index) and
+#'   lag index.
 #'
-#' @note To know more details about auto cross covariance, see the references.
+#' @note To see more details about auto cross covariance, check the references.
 #'
-#' @seealso See \code{\link{extractPCMScales}} for
+#' @seealso
+#' See \code{\link{extractPCMScales}} for
 #' generalized scales-based descriptors.
 #' For more details, see \code{\link{extractPCMDescScales}}
 #' and \code{\link{extractPCMPropScales}}.
@@ -27,14 +25,13 @@
 #' @export acc
 #'
 #' @references
-#' Wold, S., Jonsson, J., Sj\"{o}rstr\"{o}m, M., Sandberg,
-#' M., & R\"{a}nnar, S. (1993).
+#' Wold, S., Jonsson, J., Sjörström, M., Sandberg, M., & Rännar, S. (1993).
 #' DNA and peptide sequences and chemical processes multivariately modelled
 #' by principal component analysis and partial least-squares projections
 #' to latent structures.
 #' \emph{Analytica chimica acta}, 277(2), 239--253.
 #'
-#' Sj\"{o}str\"{o}m, M., R\"{a}nnar, S., & Wieslander, A. (1995).
+#' Sjöström, M., Rännar, S., & Wieslander, Å. (1995).
 #' Polypeptide sequence property relationships in \emph{Escherichia coli}
 #' based on auto cross covariances.
 #' \emph{Chemometrics and intelligent laboratory systems}, 29(2), 295--305.
@@ -42,11 +39,9 @@
 #' @examples
 #' p = 8    # p is the scales number
 #' n = 200  # n is the amino acid number
-#' lag = 7  # the lag paramter
+#' lag = 7  # lag parameter
 #' mat = matrix(rnorm(p * n), nrow = p, ncol = n)
 #' acc(mat, lag)
-#'
-
 acc = function (mat, lag) {
 
     p = nrow(mat)

--- a/R/Rcpi-datalist.R
+++ b/R/Rcpi-datalist.R
@@ -43,13 +43,13 @@ NULL
 #' This dataset includes the meta information of
 #' the 20 amino acids used for the 2D and 3D descriptor
 #' calculation in this package. Each column represents:
-#' \itemize{
-#' \item{\code{AAName}} {Amino Acid Name}
-#' \item{\code{Short}} {One-Letter Representation}
-#' \item{\code{Abbreviation}} {Three-Letter Representation}
-#' \item{\code{mol}} {SMILE Representation}
-#' \item{\code{PUBCHEM_COMPOUND_CID}} {PubChem CID for the Amino Acid}
-#' \item{\code{PUBCHEM_LINK}} {PubChem Link for the Amino Acid}
+#' \describe{
+#'   \item{\code{AAName}}{Amino acid name}
+#'   \item{\code{Short}}{One-letter representation}
+#'   \item{\code{Abbreviation}}{Three-letter representation}
+#'   \item{\code{mol}}{SMILES representation}
+#'   \item{\code{PUBCHEM_COMPOUND_CID}}{PubChem CID for the amino acid}
+#'   \item{\code{PUBCHEM_LINK}}{PubChem link for the amino acid}
 #' }
 #'
 #' @docType data
@@ -57,7 +57,6 @@ NULL
 #' @return AAMetaInfo data
 #' @examples
 #' data(AAMetaInfo)
-#'
 NULL
 
 #' 2D Descriptors for 20 Amino Acids calculated by MOE 2011.10

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,7 +4,7 @@ template:
   bootstrap: 5
 
 reference:
-  - title: "Protein sequence retrivial"
+  - title: "Protein sequence retrieval"
     desc: >
       Retrieve protein sequence data from online databases.
     contents:
@@ -15,7 +15,7 @@ reference:
     - getSeqFromUniProt
     - getSeqFromKEGG
     - getSeqFromRCSBPDB
-  - title: "Drug molecular data retrivial"
+  - title: "Drug molecular data retrieval"
     desc: >
       Retrieve drug molecular data from online databases.
     contents:
@@ -188,7 +188,7 @@ reference:
     - extractDrugOBMACCS
   - title: "PPI and CPI descriptors"
     desc: >
-      Compute protein-protein and compound-protein interation descriptors.
+      Compute protein-protein and compound-protein interaction descriptors.
     contents:
     - getPPI
     - getCPI

--- a/man/AAMetaInfo.Rd
+++ b/man/AAMetaInfo.Rd
@@ -14,16 +14,15 @@ Meta Information for the 20 Amino Acids
 This dataset includes the meta information of
 the 20 amino acids used for the 2D and 3D descriptor
 calculation in this package. Each column represents:
-\itemize{
-\item{\code{AAName}} {Amino Acid Name}
-\item{\code{Short}} {One-Letter Representation}
-\item{\code{Abbreviation}} {Three-Letter Representation}
-\item{\code{mol}} {SMILE Representation}
-\item{\code{PUBCHEM_COMPOUND_CID}} {PubChem CID for the Amino Acid}
-\item{\code{PUBCHEM_LINK}} {PubChem Link for the Amino Acid}
+\describe{
+  \item{\code{AAName}}{Amino acid name}
+  \item{\code{Short}}{One-letter representation}
+  \item{\code{Abbreviation}}{Three-letter representation}
+  \item{\code{mol}}{SMILES representation}
+  \item{\code{PUBCHEM_COMPOUND_CID}}{PubChem CID for the amino acid}
+  \item{\code{PUBCHEM_LINK}}{PubChem link for the amino acid}
 }
 }
 \examples{
 data(AAMetaInfo)
-
 }

--- a/man/acc.Rd
+++ b/man/acc.Rd
@@ -16,37 +16,31 @@ acc(mat, lag)
 }
 \value{
 A length \code{lag * p^2} named vector, the element names are
-        constructed by: the scales index (crossed scales index) and
-        lag index.
+  constructed by: the scales index (crossed scales index) and
+  lag index.
 }
 \description{
-Auto Cross Covariance (ACC) for Generating Scales-Based Descriptors
-of the Same Length
-}
-\details{
-This function calculates the auto covariance and auto cross covariance
+Calculates auto covariance and auto cross covariance
 for generating scale-based descriptors of the same length.
 }
 \note{
-To know more details about auto cross covariance, see the references.
+To see more details about auto cross covariance, check the references.
 }
 \examples{
 p = 8    # p is the scales number
 n = 200  # n is the amino acid number
-lag = 7  # the lag paramter
+lag = 7  # lag parameter
 mat = matrix(rnorm(p * n), nrow = p, ncol = n)
 acc(mat, lag)
-
 }
 \references{
-Wold, S., Jonsson, J., Sj\"{o}rstr\"{o}m, M., Sandberg,
-M., & R\"{a}nnar, S. (1993).
+Wold, S., Jonsson, J., Sjörström, M., Sandberg, M., & Rännar, S. (1993).
 DNA and peptide sequences and chemical processes multivariately modelled
 by principal component analysis and partial least-squares projections
 to latent structures.
 \emph{Analytica chimica acta}, 277(2), 239--253.
 
-Sj\"{o}str\"{o}m, M., R\"{a}nnar, S., & Wieslander, A. (1995).
+Sjöström, M., Rännar, S., & Wieslander, Å. (1995).
 Polypeptide sequence property relationships in \emph{Escherichia coli}
 based on auto cross covariances.
 \emph{Chemometrics and intelligent laboratory systems}, 29(2), 295--305.

--- a/man/extractProtPSSMAcc.Rd
+++ b/man/extractProtPSSMAcc.Rd
@@ -36,8 +36,7 @@ pssmacc = extractProtPSSMAcc(pssmmat, lag = 3)
 tail(pssmacc)}
 }
 \references{
-Wold, S., Jonsson, J., Sj\"{o}rstr\"{o}m, M., Sandberg,
-M., & R\"{a}nnar, S. (1993).
+Wold, S., Jonsson, J., Sjörström, M., Sandberg, M., & Rännar, S. (1993).
 DNA and peptide sequences and chemical processes multivariately modelled
 by principal component analysis and partial least-squares projections
 to latent structures.

--- a/man/readFASTA.Rd
+++ b/man/readFASTA.Rd
@@ -27,18 +27,10 @@ annotations (execution time is divided approximately
 by a factor 3). Default value is \code{FALSE}.}
 }
 \value{
-The result character vector
+Character vector.
 }
 \description{
-Read Protein Sequences in FASTA Format
-}
-\details{
-This function reads protein sequences in FASTA format.
-}
-\note{
-Note that any different sets of instances (chunklets),
-      e.g. {1, 3, 7} and {4, 6}, might belong to the
-      same class and might belong to different classes.
+Reads protein sequences in FASTA format.
 }
 \examples{
 P00750 = readFASTA(system.file('protseq/P00750.fasta', package = 'Rcpi'))
@@ -48,7 +40,7 @@ P00750
 Pearson, W.R. and Lipman, D.J. (1988)
 Improved tools for biological sequence comparison.
 \emph{Proceedings of the National Academy of Sciences
-of the United States of America}, \bold{85}: 2444-2448
+of the United States of America}, 85: 2444-2448.
 }
 \seealso{
 See \code{\link{readPDB}} for reading protein sequences


### PR DESCRIPTION
This PR fixes the check notes on lost braces from `checkRd` when running `R CMD check`.

Also fixes typos in `_pkgdown.yml`.